### PR TITLE
Develop

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -51,7 +51,11 @@ module.exports = {
         capIsNew: true,
       },
     ],
-    'no-mixed-operators': 'error',
+    'no-mixed-operators': [
+      'error',
+      {
+        groups: [['&&', '||']],
+      }
     'no-multi-assign': 'error',
     'no-negated-condition': 'warn',
     'no-unneeded-ternary': [

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ available for
 * Add page elevator.
 * Add images resizer (Currently 100%, 125%, 150%, 175%, 200% of browser height). 
 * Add Shortcuts:
-  * `left click` `numpad 3` `numpad 6`: go to next page.
-  * `right click` `numpad 1` `numpad 4`: go to previous page.
+  * `left click` `numpad 3` `numpad 6` `space`: go to next page.
+  * `right click` `numpad 1` `numpad 4` `backspace`: go to previous page.
   * `mouse wheel up` (when hovering enhencer): go to next page.
   * `mouse wheel down` (when hovering enhencer): go to previous page.
   * `ctrl + →`: go to next 10 page.

--- a/src/components/GalleryEnhencer/GalleryEnhencer.vue
+++ b/src/components/GalleryEnhencer/GalleryEnhencer.vue
@@ -23,9 +23,9 @@ const {
 } = usePreloadDownloadLinks()
 
 const {
-  rightWithPx,
-  archiveTopWithPx,
-  torrentTopWithPx,
+  popupRight,
+  archiveTop,
+  torrentTop,
 } = usePosition()
 
 preloadDownloadLinks()
@@ -36,6 +36,7 @@ setImagesContainerWheelEvent()
 </script>
 
 <style lang="scss">
+/* stylelint-disable function-name-case */
 div#gmid {
   width: 931px;
 }
@@ -46,14 +47,14 @@ div#gd5 {
 
 .popup {
   position: absolute;
-  right: v-bind(rightWithPx);
+  right: calc(v-bind(popupRight) * 1px);
 
   &--archive {
-    top: v-bind(archiveTopWithPx);
+    top: calc(v-bind(archiveTop) * 1px);
   }
 
   &--torrent {
-    top: v-bind(torrentTopWithPx);
+    top: calc(v-bind(torrentTop) * 1px);
   }
 }
 </style>

--- a/src/components/GalleryEnhencer/composables/useDownloadEvents.ts
+++ b/src/components/GalleryEnhencer/composables/useDownloadEvents.ts
@@ -30,7 +30,9 @@ export default function() {
     for (const link of hentaiAtHomeLinks) {
       link.removeAttribute('onclick')
 
-      link.addEventListener('click', async () => {
+      link.addEventListener('click', async event => {
+        event.preventDefault()
+
         const originalText = replaceLinkByLoadingIcon(link)
 
         const doc = await sendDownloadRequest(link, postUrl)

--- a/src/components/GalleryEnhencer/composables/usePositions.ts
+++ b/src/components/GalleryEnhencer/composables/usePositions.ts
@@ -29,12 +29,12 @@ export default function() {
 
   function getArchiveTop(): number {
     const { top, height } = archiveLinkAnchor.getBoundingClientRect()
-    return top + height + 5
+    return top + height + window.scrollY + 5
   }
 
   function getTorrentTop(): number {
     const { top, height } = torrentLinkAnchor.getBoundingClientRect()
-    return top + height + 5
+    return top + height + window.scrollY + 5
   }
 
   return {

--- a/src/components/GalleryEnhencer/composables/usePositions.ts
+++ b/src/components/GalleryEnhencer/composables/usePositions.ts
@@ -1,34 +1,45 @@
 import { ref } from 'vue'
-import { useResizeObserver } from '@vueuse/core'
+import { useMutationObserver } from '@vueuse/core'
 
 import useElement from './useElements'
 
 export default function() {
   const { archiveLinkAnchor, torrentLinkAnchor, infoDiv } = useElement()
 
-  const rightWithPx = ref('0')
-  useResizeObserver(document.documentElement, () => {
+  const popupRight = ref(0)
+  const archiveTop = ref(0)
+  const torrentTop = ref(0)
+
+  useMutationObserver(infoDiv, () => {
     if (!infoDiv) {
       return
     }
-    rightWithPx.value = `${(document.documentElement.clientWidth - infoDiv.clientWidth) / 2}px`
+
+    popupRight.value = getPopupRight()
+    archiveTop.value = getArchiveTop()
+    torrentTop.value = getTorrentTop()
+  }, {
+    childList: true,
+    subtree: true,
   })
 
-  const archiveTopWithPx = ref('0')
-  ;(() => {
-    const { top, height } = archiveLinkAnchor.getBoundingClientRect()
-    archiveTopWithPx.value = `${top + height + 5}px`
-  })()
+  function getPopupRight(): number {
+    return (document.documentElement.clientWidth - infoDiv.clientWidth) / 2
+  }
 
-  const torrentTopWithPx = ref('0')
-  ;(() => {
+  function getArchiveTop(): number {
+    const { top, height } = archiveLinkAnchor.getBoundingClientRect()
+    return top + height + 5
+  }
+
+  function getTorrentTop(): number {
     const { top, height } = torrentLinkAnchor.getBoundingClientRect()
-    torrentTopWithPx.value = `${top + height + 5}px`
-  })()
+    return top + height + 5
+  }
 
   return {
-    rightWithPx,
-    archiveTopWithPx,
-    torrentTopWithPx,
+    popupRight,
+    archiveTop,
+    torrentTop,
   }
 }

--- a/src/components/MultiPageViewerEnhencer/components/ImageResizer.vue
+++ b/src/components/MultiPageViewerEnhencer/components/ImageResizer.vue
@@ -17,7 +17,7 @@ import { computed, ref } from 'vue'
 import usePages from '../composables/usePages'
 import useElements from '../composables/useElements'
 
-const { scrollToRelativePosition, getCurrentImage } = usePages()
+const { scrollToRelativePosition, scrollToImageTop, getCurrentImage } = usePages()
 const { paneImagesDiv } = useElements()
 const {
   heightList,
@@ -48,7 +48,7 @@ function useImageResizer() {
       setImageHeight(index)
     }
 
-    scrollToRelativePosition(relativeToViewport)
+    scroll(relativeToViewport)
   }
 
   function setImageHeight(index: number) {
@@ -84,6 +84,14 @@ function useImageResizer() {
     return 1 - ((imageHeight - 1 + imageTop - window.innerHeight / 2) / imageHeight)
   }
 
+  function scroll(relativeToViewport: number) {
+    if (currentHeight.value === 100) {
+      scrollToImageTop()
+    } else {
+      scrollToRelativePosition(relativeToViewport)
+    }
+  }
+
   function setResizeShortcuts() {
     window.addEventListener('keydown', event => {
       const relativeToViewport = getRelativeToViewport()
@@ -97,48 +105,47 @@ function useImageResizer() {
 
         const index = Number(matchResult.groups?.index)
         setImageHeight(index - 1)
-        scrollToRelativePosition(relativeToViewport)
-        return
-      }
+      } else {
 
-      switch (event.code) {
-        case 'NumpadAdd':
-          increaseImageHeight()
-          scrollToRelativePosition(relativeToViewport)
-
-          break
-
-        case 'NumpadSubtract':
-          decreaseImageHeight()
-          scrollToRelativePosition(relativeToViewport)
-          break
-
-        case 'Numpad0':
-          if (currentIndex.value === 0) {
-            clearImageHeight()
-          } else {
-            setImageHeight(0)
+        switch (event.code) {
+          case 'NumpadAdd':
+            increaseImageHeight()
+            break
+  
+          case 'NumpadSubtract':
+            decreaseImageHeight()
+            break
+  
+          case 'Numpad0':
+            if (currentIndex.value === 0) {
+              clearImageHeight()
+            } else {
+              setImageHeight(0)
+            }
+  
+            break
+  
+          case 'NumpadDecimal': {
+            const index = Math.floor(heightList.length / 2)
+            if (currentIndex.value === index) {
+              clearImageHeight()
+            } else {
+              setImageHeight(index)
+            }
+  
+            break
           }
-          scrollToRelativePosition(relativeToViewport)
-          break
-
-        case 'NumpadDecimal': {
-          const index = Math.floor(heightList.length / 2)
-          if (currentIndex.value === index) {
+  
+          case 'NumpadEnter':
             clearImageHeight()
-          } else {
-            setImageHeight(index)
-          }
-
-          scrollToRelativePosition(relativeToViewport)
-          break
+            break
+  
+          default:
+            return
         }
-
-        case 'NumpadEnter':
-          clearImageHeight()
-          scrollToRelativePosition(relativeToViewport)
-          break
       }
+
+      scroll(relativeToViewport)
     })
   }
 

--- a/src/components/MultiPageViewerEnhencer/components/ImageResizer.vue
+++ b/src/components/MultiPageViewerEnhencer/components/ImageResizer.vue
@@ -85,10 +85,16 @@ function useImageResizer() {
   }
 
   function scroll(relativeToViewport: number) {
+    const currentImage = getCurrentImage()
+
     if (currentHeight.value === 100) {
       scrollToImageTop()
     } else {
       scrollToRelativePosition(relativeToViewport)
+    }
+    
+    if (currentImage.getBoundingClientRect().top > 1) {
+      scrollToImageTop()
     }
   }
 

--- a/src/components/MultiPageViewerEnhencer/composables/useEvents.ts
+++ b/src/components/MultiPageViewerEnhencer/composables/useEvents.ts
@@ -74,10 +74,16 @@ export default function() {
           case 'Numpad4':
             goToPrevPage()
             break
+            
+          case 'Backspace':
+            event.preventDefault()
+            goToPrevPage()
+            break
 
           case 'ArrowRight':
           case 'Numpad3':
           case 'Numpad6':
+          case 'Space':
             goToNextPage()
             break
 

--- a/src/components/MultiPageViewerEnhencer/composables/useEvents.ts
+++ b/src/components/MultiPageViewerEnhencer/composables/useEvents.ts
@@ -1,12 +1,12 @@
 import { debounce } from 'lodash-es'
 
-import { getElement, scrollElement } from '@/utils/commons'
+import { scrollElement } from '@/utils/commons'
 
 import usePages from './usePages'
 import useElements from './useElements'
 
 const {
-  currentImageContainer,
+  getCurrentImage,
   goToPageByOffset,
   goToNextPage,
   goToPrevPage,
@@ -35,7 +35,7 @@ export default function() {
             break
         }
       } else {
-        const currentImage = getElement('img[id^=imgsrc_]', currentImageContainer.value as HTMLElement)
+        const currentImage = getCurrentImage()
         switch (event.code) {
           case 'Numpad8': // 置頂
             if (currentImage) {

--- a/src/components/MultiPageViewerEnhencer/composables/useEvents.ts
+++ b/src/components/MultiPageViewerEnhencer/composables/useEvents.ts
@@ -1,6 +1,6 @@
 import { debounce } from 'lodash-es'
 
-import { scrollElement } from '@/utils/commons'
+import { getElement, scrollElement } from '@/utils/commons'
 
 import usePages from './usePages'
 import useElements from './useElements'
@@ -35,19 +35,30 @@ export default function() {
             break
         }
       } else {
-        const top = (currentImageContainer.value as HTMLElement).offsetTop
-        const height = (currentImageContainer.value as HTMLElement).offsetHeight
+        const currentImage = getElement('img[id^=imgsrc_]', currentImageContainer.value as HTMLElement)
         switch (event.code) {
           case 'Numpad8': // 置頂
-            scrollElement(paneImagesDiv, { absolute: top })
+            if (currentImage) {
+              scrollElement(paneImagesDiv, {
+                absolute: currentImage.offsetTop,
+              })
+            }
             break
 
           case 'Numpad5': // 置中
-            scrollElement(paneImagesDiv, { absolute: top + ((height - window.innerHeight) / 2) })
+            if (currentImage) {
+              scrollElement(paneImagesDiv, {
+                absolute: currentImage.offsetTop + ((currentImage.offsetHeight - window.innerHeight) / 2),
+              })
+            }
             break
 
           case 'Numpad2': // 置底
-            scrollElement(paneImagesDiv, { absolute: top + height - window.innerHeight })
+            if (currentImage) {
+              scrollElement(paneImagesDiv, {
+                absolute: currentImage.offsetTop + currentImage.offsetHeight - window.innerHeight,
+              })
+            }
             break
 
           case 'ArrowUp':

--- a/src/components/MultiPageViewerEnhencer/composables/usePages.ts
+++ b/src/components/MultiPageViewerEnhencer/composables/usePages.ts
@@ -63,6 +63,10 @@ export default function() {
     target.scrollIntoView()
   }
 
+  function scrollToImageTop() {
+    getCurrentImage().scrollIntoView()
+  }
+
   function scrollToRelativePosition(relativeToViewport: number) {
     const currentImage = getCurrentImage()
     const { height: imageHeight } = currentImage.getBoundingClientRect()
@@ -102,6 +106,7 @@ export default function() {
     goToPrevPage,
     goToPageByOffset,
     goToPage,
+    scrollToImageTop,
     scrollToRelativePosition,
     changePageOnClick,
     setCurrentPageUpdateEvent,

--- a/src/components/MultiPageViewerEnhencer/composables/usePages.ts
+++ b/src/components/MultiPageViewerEnhencer/composables/usePages.ts
@@ -8,7 +8,6 @@ import useElements from './useElements'
 const { paneImagesDiv } = useElements()
 
 const currentPage = ref(unsafeWindow.currentpage)
-const currentImageContainer = computed(() => getElement(`#image_${currentPage.value}`))
 
 export default function() {
   const pageCount = unsafeWindow.pagecount
@@ -64,9 +63,12 @@ export default function() {
     target.scrollIntoView()
   }
 
-  function goToCurrentPage() {
-    const target = getElement(`#image_${currentPage.value}`) as HTMLElement
-    target.scrollIntoView()
+  function scrollToRelativePosition(relativeToViewport: number) {
+    const currentImage = getCurrentImage()
+    const { height: imageHeight } = currentImage.getBoundingClientRect()
+    const top = currentImage.offsetTop + relativeToViewport * imageHeight - window.innerHeight / 2 - 1
+
+    paneImagesDiv.scrollTo({ top })
   }
 
   function changePageOnClick(event: WheelEvent) {
@@ -87,16 +89,20 @@ export default function() {
     }
   }
 
+  function getCurrentImage() {
+    return getElement(`img[id^=imgsrc_${currentPage.value}]`) as HTMLElement
+  }
+
   return {
     appendPageIndex,
     pageCount,
     currentPage,
-    currentImageContainer,
+    getCurrentImage,
     goToNextPage,
     goToPrevPage,
     goToPageByOffset,
     goToPage,
-    goToCurrentPage,
+    scrollToRelativePosition,
     changePageOnClick,
     setCurrentPageUpdateEvent,
   }


### PR DESCRIPTION
1. fix(multipage): correct the position of scrolling to middle/bottom of image
2. fix(gallery): change updatetiming of position of popup
3. fix(gallery): set preventDefault() to H@H download links
4. feat(multipage): keep scrolltop of image relatively after changing image size
5. feat(multipage): add keyboard shortcuts space backsapce
6. feat(multipage): scroll image to fill viewport if size set to 100
7. fix(gallery): fix top of popup
8. fix(multipage): prevent going back to previous page after decrease image size